### PR TITLE
[5.1] Fixed function not found error

### DIFF
--- a/src/Illuminate/Filesystem/Filesystem.php
+++ b/src/Illuminate/Filesystem/Filesystem.php
@@ -199,6 +199,10 @@ class Filesystem
      */
     public function mimeType($path)
     {
+        if (!extension_loaded("fileinfo")) {
+            return '"fileinfo" PECL extension has not been loaded.';
+        }
+        
         return finfo_file(finfo_open(FILEINFO_MIME_TYPE), $path);
     }
 


### PR DESCRIPTION
If the server doesn't find "php_fileinfo.dll" extension it is throwing a php error: function not found finfo_file(). It is fixed and now is returning a message.